### PR TITLE
Corregir el nodo principal de xml y mejorar exportación (version 2.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -65,7 +65,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -83,7 +83,7 @@ jobs:
         php-versions: ['8.2', '8.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -96,7 +96,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,11 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
-          tools: cs2pr, phive
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
-      - name: Install phpcs
-        run: phive install phpcs --trust-gpg-keys 5E6DDE998AB73B8E
       - name: Code style (phpcs)
-        run: tools/phpcs -q --report=checkstyle | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -28,7 +28,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -38,7 +38,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: build/coverage
@@ -73,7 +73,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
@@ -86,7 +86,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -94,7 +94,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
           path: build/coverage

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist --no-dev
       - name: System test with PHP ${{ matrix.php-versions }}
-        run: php bin/sat-pys-scraper --format xml --sort key build/result.xml
+        run: php bin/sat-pys-scraper --json build/result.json --xml build/result.xml --sort key

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -22,7 +22,7 @@ jobs:
         php-versions: ['8.2', '8.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,7 +35,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.41.1" installed="3.41.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.8.0" installed="3.8.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.8.0" installed="3.8.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.50" installed="1.10.50" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.41.1" installed="2.41.1" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.51.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.9.0" installed="3.9.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.9.0" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.60" installed="1.10.60" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/Docker.README.md
+++ b/Docker.README.md
@@ -23,14 +23,14 @@ docker run -it --rm --user="$(id -u):$(id -g)" \
 
 # generar en un volumen
 docker run -it --rm --user="$(id -u):$(id -g)" --volume="${PWD}:/local" \
-  sat-pys-scraper /local/output.xml
+  sat-pys-scraper --xml /local/output.xml
 
 
 # pipe output to file (xml, sorted by key)
 docker run -it --rm --user="$(id -u):$(id -g)" \
-  sat-pys-scraper - > output.xml
+  sat-pys-scraper --xml - > output.xml
 
 # pipe output to file (json, sorted by name)
 docker run -it --rm --user="$(id -u):$(id -g)" \
-  sat-pys-scraper - --format json --sort name > output.xml
+  sat-pys-scraper --json - --sort name > output.json
 ```

--- a/README.md
+++ b/README.md
@@ -62,19 +62,23 @@ sat-pys-scraper - Crea un archivo con la clasificación de productos y servicios
 
 Sintaxis:
     sat-pys-scraper help|-h|--help
-    sat-pys-scraper destination-file [--quiet|-q] [--format|-f FORMAT]
+    sat-pys-scraper [--quiet|-q] [--json|-j JSON_FILE] [--xml|-x XML_FILE]
 
 Argumentos:
-    destination-file
-        Nombre del archivo XML para almacenar el resultado.
-        Si se usa "-" o se omite entonces el resultado se manda a la salida estándar
-        y se activa el modo de operación silencioso.
-    --format|-f FORMAT
-        Establece el formato de salida, default: xml, por el momento "xml" o "json".
+    --xml|-x XML_FILE
+        Establece el nombre de archivo, o "-" para la salida estándar, donde se envían
+        los datos generados en formato XML.
+    --json|-j JSON_FILE
+        Establece el nombre de archivo, o "-" para la salida estándar, donde se envían
+        los datos generados en formato JSON.
     --sort|-s SORT
         Establece el orden de elementos, default: key, se puede usar "key" o "name".
     --quiet|-q
         Modo de operación silencioso.
+
+Notas:
+    Debe especificar al menos un argumento "--xml" o "--json", o ambos.
+    No se puede especificar "-" como salida de "--xml" y "--json" al mismo tiempo.
 
 Acerca de:
     Este script pertenece al proyecto https://github.com/phpcfdi/sat-pys-scraper

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ Esta librería se mantendrá compatible con al menos la versión con
 También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes usar esta librería
 sin temor a romper tu aplicación.
 
-| Version | PHP | Notes      |
-|---------|-----|------------|
-| 1.0.0   | 8.2 | 2023-12-13 |
+| Version | PHP      | Notes      |
+|---------|----------|------------|
+| 1.0.0   | 8.2, 8.3 | 2023-12-13 |
+| 2.0.0   | 8.2, 8.3 | 2024-03-07 |
 
 ## Contribuciones
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,16 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 2.0.0 2023-03-07
+
+- Se corrige el nodo principal, el nombre correcto es `<pys>`.
+- Se cambia el comando de ejecución `bin/sat-pys-scraper` para exportar a JSON y XML al mismo tiempo.
+
+Otros cambios:
+
+- Se utilizan las acciones de GitHub versión 4. 
+- Se actualizan las herramientas de desarrollo.
+
 ### Versión 1.0.0 2023-12-13
 
 - Versión inicial.

--- a/src/XmlExporter.php
+++ b/src/XmlExporter.php
@@ -20,7 +20,7 @@ final class XmlExporter
         $document = new DOMDocument();
         $document->formatOutput = true;
         /** @noinspection PhpUnhandledExceptionInspection */
-        $root = $document->createElement('psy');
+        $root = $document->createElement('pys');
         $document->appendChild($root);
 
         foreach ($types as $type) {

--- a/tests/_files/exported-fake.xml
+++ b/tests/_files/exported-fake.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<psy>
+<pys>
   <type key="1" name="Productos">
     <segment key="27" name="Herramientas y Maquinaria General">
       <family key="2711" name="Herramientas de mano">
@@ -49,4 +49,4 @@
       </family>
     </segment>
   </type>
-</psy>
+</pys>


### PR DESCRIPTION
- Se corrige el nodo principal, el nombre correcto es `<pys>`.
- Se cambia el comando de ejecución `bin/sat-pys-scraper` para exportar a JSON y XML al mismo tiempo.
- Se utilizan las acciones de GitHub versión 4. 
- Se actualizan las herramientas de desarrollo.
