### PR TITLE
Mejoras en la integración contínua y pruebas (versión 3.0.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,18 +76,18 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-version: ['8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: xdebug
           tools: composer:v2
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.3 (code coverage)
+    name: Create code coverage
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -15,18 +15,18 @@ on:
 jobs:
 
   system-tests:
-    name: System test on PHP ${{ matrix.php-versions }}
+    name: System test on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-version: ['8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: xdebug
           tools: composer:v2
         env:
@@ -42,5 +42,5 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist --no-dev
-      - name: System test with PHP ${{ matrix.php-versions }}
+      - name: System test with PHP ${{ matrix.php-version }}
         run: php bin/sat-pys-scraper --json build/result.json --xml build/result.xml --sort key

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.51.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.9.0" installed="3.9.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.9.0" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.60" installed="1.10.60" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.64.0" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.10.2" installed="3.10.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.10.2" installed="3.10.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.12.3" installed="1.12.3" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.43.0" installed="2.43.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/Docker.README.md
+++ b/Docker.README.md
@@ -21,10 +21,9 @@ The project installed on `/opt/sat-pys-scraper/` and the entry point is the comm
 docker run -it --rm --user="$(id -u):$(id -g)" \
   sat-pys-scraper --help
 
-# generar en un volumen
+# create output using volume
 docker run -it --rm --user="$(id -u):$(id -g)" --volume="${PWD}:/local" \
   sat-pys-scraper --xml /local/output.xml
-
 
 # pipe output to file (xml, sorted by key)
 docker run -it --rm --user="$(id -u):$(id -g)" \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2023 - 2024 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ Un objeto `Classification` solamente contiene las propiedades `key` y `name`.
 
 Todos los objetos de datos implementan `JsonSerializable`, por lo que puedes usar esta característica para exportar a formato JSON.
 
+### Excepciones
+
+La clase `Scraper` y -por consecuencia- también la clase `Generator` generan excepciones.
+En el caso de una excepción de tipo HTTP se tira una excepción `HttpException`.
+En el caso de una excepción HTTP y tenga un código de error del servicio remoto se tira una excepción `HttpServerException`.
+
+La jerarquía de excepciones es:
+
+```text
+- PysException (interface)
+    - HttpException (class)
+        - HttpServerException (class)
+```
+
 ## Soporte
 
 Puedes obtener soporte abriendo un ticket en Github.

--- a/bin/sat-pys-scraper
+++ b/bin/sat-pys-scraper
@@ -3,26 +3,8 @@
 
 declare(strict_types=1);
 
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use PhpCfdi\SatPysScraper\App\SatPysScraper;
-use PhpCfdi\SatPysScraper\Scraper;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$scraperWithRetry = (function () {
-    $decider = fn (int $retries, RequestInterface $request, ResponseInterface $response = null): bool
-        => $retries < 5 && null !== $response && $response->getStatusCode() >= 500;
-    $delay = fn (int $retries): int => 1000 * ($retries + 1);
-
-    $stack = HandlerStack::create();
-    $stack->push(Middleware::retry($decider, $delay));
-    $client = new Client(['handler' => $stack]);
-
-    return new Scraper($client);
-})();
-
-exit(SatPysScraper::run($argv, $scraperWithRetry));
+exit(SatPysScraper::run($argv));

--- a/bin/sat-pys-scraper
+++ b/bin/sat-pys-scraper
@@ -3,8 +3,26 @@
 
 declare(strict_types=1);
 
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use PhpCfdi\SatPysScraper\App\SatPysScraper;
+use PhpCfdi\SatPysScraper\Scraper;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-exit(SatPysScraper::run($argv));
+$scraperWithRetry = (function () {
+    $decider = fn (int $retries, RequestInterface $request, ResponseInterface $response = null): bool
+        => $retries < 5 && null !== $response && $response->getStatusCode() >= 500;
+    $delay = fn (int $retries): int => 1000 * ($retries + 1);
+
+    $stack = HandlerStack::create();
+    $stack->push(Middleware::retry($decider, $delay));
+    $client = new Client(['handler' => $stack]);
+
+    return new Scraper($client);
+})();
+
+exit(SatPysScraper::run($argv, $scraperWithRetry));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,21 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 3.0.1 2024-09-17
+
+Se modifica el script de ejecución y la prueba funcional para poder reintentar en caso de que el 
+servidor del SAT devuelva un estado HTTP 500. Esto sucede frecuentemente desde hace un par de meses.
+
+Se cambia la construcción de imagen de docker, ahora depende de `php:8.3-cli-alpine`.
+
+Se actualiza el archivo de licencia a 2024.
+
+Se hacen otros cambios en el entorno de desarrollo:
+
+- Se prueba el correcto orden para llamar a los métodos para obtener datos.
+- Se utiliza la variable `php-version` en singular para las matrices de pruebas.
+- Se actualizan las herramientas de desarrollo.
+
 ### Versión 3.0.0 2024-03-07
 
 - Se cambia el método `SatPysScraper::run()` para una mejor inyección de dependencias y capacidad de pruebas.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,13 +11,13 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
-### Versión 3.0.0 2023-03-07
+### Versión 3.0.0 2024-03-07
 
 - Se cambia el método `SatPysScraper::run()` para una mejor inyección de dependencias y capacidad de pruebas.
 - Se introduce una excepción dedicada para los errores de procesamiento de argumentos.
 - Se cambia la forma de procesar los argumentos para usar `array_shift`.
 
-### Versión 2.0.0 2023-03-07
+### Versión 2.0.0 2024-03-07
 
 - Se corrige el nodo principal, el nombre correcto es `<pys>`.
 - Se cambia el comando de ejecución `bin/sat-pys-scraper` para exportar a JSON y XML al mismo tiempo.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,13 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
-### Versión 3.0.1 2024-09-17
+### Versión 3.0.1 2024-10-15
+
+La aplicación del SAT devuelve un error 500 frecuentemente (1 de cada 3 veces) desde 2024-07-15.
+Este error parece estar relacionado con la distribución de cargas por parte del SAT, así que
+reintentar la llamada HTTP sobre la misma conexión no soluciona el problema y hay que crear
+un nuevo cliente HTTP. Para intentar solventarlo, se modifica la librería para tirar
+excepciones con errores HTTP e intentar solventar el error.
 
 Se cambia la construcción de imagen de docker, ahora depende de `php:8.3-cli-alpine`.
 
@@ -19,6 +25,7 @@ Se actualiza el archivo de licencia a 2024.
 
 Se hacen otros cambios en el entorno de desarrollo:
 
+- Se modifica la prueba funcional para poder hacer hasta 5 reintentos reconstruyendo el cliente http.
 - Se prueba el correcto orden para llamar a los métodos para obtener datos.
 - Se utiliza la variable `php-version` en singular para las matrices de pruebas.
 - Se actualizan las herramientas de desarrollo.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,9 +13,6 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ### Versión 3.0.1 2024-09-17
 
-Se modifica el script de ejecución y la prueba funcional para poder reintentar en caso de que el 
-servidor del SAT devuelva un estado HTTP 500. Esto sucede frecuentemente desde hace un par de meses.
-
 Se cambia la construcción de imagen de docker, ahora depende de `php:8.3-cli-alpine`.
 
 Se actualiza el archivo de licencia a 2024.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,12 +2,6 @@
 
 ## Lista de tareas pendientes
 
-### `phcps`
-
-En el flujo de trabajo `build.yml` usando `actions/setup-php-action` la herramienta `phcps` se está instalando usando `squizlabs` en lugar de `PHPCSStandards`.
-Por lo tanto, en lugar de usar la herramienta de la acción, se está usando `phive` para instalarla.
-Cuando se actualice la herramienta `actions/setup-php-action` se debe cambiar a la instalación normal.
-
 ### PHP 8.3
 
 Migrar a PHP 8.3 en cuanto las herramientas (como *PHP_CodeSniffer*) lo permitan.

--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Exceptions;
+
+use RuntimeException;
+
+class HttpException extends RuntimeException implements PysException
+{
+}

--- a/src/Exceptions/HttpServerException.php
+++ b/src/Exceptions/HttpServerException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Exceptions;
+
+class HttpServerException extends HttpException
+{
+}

--- a/src/Exceptions/PysException.php
+++ b/src/Exceptions/PysException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Exceptions;
+
+interface PysException
+{
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatPysScraper;
 
+use PhpCfdi\SatPysScraper\Exceptions\HttpException;
+use PhpCfdi\SatPysScraper\Exceptions\HttpServerException;
+
 readonly class Generator
 {
     public function __construct(
@@ -12,6 +15,9 @@ readonly class Generator
     ) {
     }
 
+    /**
+     * @throws HttpServerException|HttpException
+     */
     public function generate(): Data\Types
     {
         $types = new Data\Types();

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -14,7 +14,7 @@ final class Scraper implements ScraperInterface
     /** @noinspection HttpUrlsUsage */
     public const PYS_URL = 'http://pys.sat.gob.mx/PyS/catPyS.aspx';
 
-    private Crawler|null $crawler;
+    private Crawler|null $crawler = null;
 
     public function __construct(private readonly ClientInterface $client)
     {

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -20,14 +20,12 @@ final class Scraper implements ScraperInterface
     {
     }
 
-    /** @return array<int|string, string> */
     public function obtainTypes(): array
     {
         $crawler = $this->sendGet();
         return $this->extractSelectValues($crawler, 'cmbTipo');
     }
 
-    /** @return array<int|string, string> */
     public function obtainSegments(int|string $type): array
     {
         $inputs = [
@@ -39,7 +37,6 @@ final class Scraper implements ScraperInterface
         return $this->extractSelectValues($crawler, 'cmbSegmento');
     }
 
-    /** @return array<int|string, string> */
     public function obtainFamilies(int|string $type, int|string $segment): array
     {
         $inputs = [
@@ -52,7 +49,6 @@ final class Scraper implements ScraperInterface
         return $this->extractSelectValues($crawler, 'cmbFamilia');
     }
 
-    /** @return array<int|string, string> */
     public function obtainClasses(int|string $type, int|string $segment, int|string $family): array
     {
         $inputs = [

--- a/src/ScraperInterface.php
+++ b/src/ScraperInterface.php
@@ -8,21 +8,25 @@ interface ScraperInterface
 {
     /**
      * @return array<int|string, string>
+     * @throws Exceptions\HttpException|Exceptions\HttpServerException
      */
     public function obtainTypes(): array;
 
     /**
      * @return array<int|string, string>
+     * @throws Exceptions\HttpException|Exceptions\HttpServerException
      */
     public function obtainSegments(int|string $type): array;
 
     /**
      * @return array<int|string, string>
+     * @throws Exceptions\HttpException|Exceptions\HttpServerException
      */
     public function obtainFamilies(int|string $type, int|string $segment): array;
 
     /**
      * @return array<int|string, string>
+     * @throws Exceptions\HttpException|Exceptions\HttpServerException
      */
     public function obtainClasses(int|string $type, int|string $segment, int|string $family): array;
 }

--- a/src/ScraperInterface.php
+++ b/src/ScraperInterface.php
@@ -6,15 +6,23 @@ namespace PhpCfdi\SatPysScraper;
 
 interface ScraperInterface
 {
-    /** @return array<int|string, string> */
+    /**
+     * @return array<int|string, string>
+     */
     public function obtainTypes(): array;
 
-    /** @return array<int|string, string> */
+    /**
+     * @return array<int|string, string>
+     */
     public function obtainSegments(int|string $type): array;
 
-    /** @return array<int|string, string> */
+    /**
+     * @return array<int|string, string>
+     */
     public function obtainFamilies(int|string $type, int|string $segment): array;
 
-    /** @return array<int|string, string> */
+    /**
+     * @return array<int|string, string>
+     */
     public function obtainClasses(int|string $type, int|string $segment, int|string $family): array;
 }

--- a/tests/Integration/ScraperTest.php
+++ b/tests/Integration/ScraperTest.php
@@ -5,34 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\SatPysScraper\Tests\Integration;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use PhpCfdi\SatPysScraper\Scraper;
-use PhpCfdi\SatPysScraper\ScraperInterface;
 use PhpCfdi\SatPysScraper\Tests\TestCase;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class ScraperTest extends TestCase
 {
-    private const MAX_RETRIES = 5;
-
-    private function createScraper(): ScraperInterface
-    {
-        $decider = fn (int $retries, RequestInterface $request, ResponseInterface $response = null): bool
-            => $retries < self::MAX_RETRIES && null !== $response && $response->getStatusCode() >= 500;
-        $delay = fn (int $retries): int => 1000 * ($retries + 1);
-
-        $stack = HandlerStack::create();
-        $stack->push(Middleware::retry($decider, $delay));
-        $client = new Client(['handler' => $stack]);
-
-        return new Scraper($client);
-    }
-
     public function testObtainSequence(): void
     {
-        $scraper = $this->createScraper();
+        $scraper = new Scraper(new Client());
 
         $types = $scraper->obtainTypes();
         $expectedTypeId = 1;

--- a/tests/Integration/ScraperTest.php
+++ b/tests/Integration/ScraperTest.php
@@ -5,12 +5,32 @@ declare(strict_types=1);
 namespace PhpCfdi\SatPysScraper\Tests\Integration;
 
 use GuzzleHttp\Client;
+use PhpCfdi\SatPysScraper\Exceptions\HttpServerException;
 use PhpCfdi\SatPysScraper\Scraper;
 use PhpCfdi\SatPysScraper\Tests\TestCase;
 
 class ScraperTest extends TestCase
 {
+    private const MAX_RETRIES = 5;
+
     public function testObtainSequence(): void
+    {
+        do {
+            $try = ($try ?? 0) + 1;
+            try {
+                $this->procedureObtainSequence();
+                $lastException = null;
+                break;
+            } catch (HttpServerException $exception) {
+                $lastException = $exception;
+            }
+        } while ($try < self::MAX_RETRIES);
+        if (null !== $lastException) {
+            throw $lastException;
+        }
+    }
+
+    public function procedureObtainSequence(): void
     {
         $scraper = new Scraper(new Client());
 

--- a/tests/Unit/Exceptions/HttpExceptionTest.php
+++ b/tests/Unit/Exceptions/HttpExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\SatPysScraper\Exceptions\HttpException;
+use PhpCfdi\SatPysScraper\Exceptions\PysException;
+use PhpCfdi\SatPysScraper\Tests\Unit\TestCase;
+
+final class HttpExceptionTest extends TestCase
+{
+    public function testClassImplementsPysException(): void
+    {
+        $exception = new HttpException('foo');
+        $this->assertInstanceOf(PysException::class, $exception);
+    }
+}

--- a/tests/Unit/Exceptions/HttpServerExceptionTest.php
+++ b/tests/Unit/Exceptions/HttpServerExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\SatPysScraper\Exceptions\HttpException;
+use PhpCfdi\SatPysScraper\Exceptions\HttpServerException;
+use PhpCfdi\SatPysScraper\Tests\Unit\TestCase;
+
+final class HttpServerExceptionTest extends TestCase
+{
+    public function testClassExtendsHttpException(): void
+    {
+        $exception = new HttpServerException('foo');
+        $this->assertInstanceOf(HttpException::class, $exception);
+    }
+}

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatPysScraper\Tests\Unit;
 
+use GuzzleHttp\Psr7\Response;
+use PhpCfdi\SatPysScraper\Exceptions\HttpException;
+use PhpCfdi\SatPysScraper\Exceptions\HttpServerException;
 use PhpCfdi\SatPysScraper\Generator;
 
 class GeneratorTest extends TestCase
@@ -18,5 +21,27 @@ class GeneratorTest extends TestCase
 
         $expectedFile = __DIR__ . '/../_files/exported-fake.json';
         $this->assertJsonStringEqualsJsonFile($expectedFile, (string) json_encode($types));
+    }
+
+    public function testGenerateThrowsExceptionOnServerError(): void
+    {
+        $scraper = $this->createPreparedScraperQueue([
+            new Response(500, body: 'Internal server error'),
+        ]);
+        $generator = new Generator($scraper);
+
+        $this->expectException(HttpServerException::class);
+        $generator->generate();
+    }
+
+    public function testGenerateThrowsExceptionOnRequestError(): void
+    {
+        $scraper = $this->createPreparedScraperQueue([
+            new Response(404, body: 'Not found'),
+        ]);
+        $generator = new Generator($scraper);
+
+        $this->expectException(HttpException::class);
+        $generator->generate();
     }
 }

--- a/tests/Unit/ScraperTest.php
+++ b/tests/Unit/ScraperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Tests\Unit;
+
+use LogicException;
+
+final class ScraperTest extends TestCase
+{
+    public function testCallObtainSegmentsWithoutCorrectSequenceThrowsLogicException(): void
+    {
+        $scraper = $this->createFakeScraper();
+        $this->expectException(LogicException::class);
+        $scraper->obtainSegments(1);
+    }
+
+    public function testCallObtainFamiliesWithoutCorrectSequenceThrowsLogicException(): void
+    {
+        $scraper = $this->createFakeScraper();
+        $this->expectException(LogicException::class);
+        $scraper->obtainFamilies(27, 1);
+    }
+
+    public function testCallObtainClassesWithoutCorrectSequenceThrowsLogicException(): void
+    {
+        $scraper = $this->createFakeScraper();
+        $this->expectException(LogicException::class);
+        $scraper->obtainClasses(2711, 27, 1);
+    }
+}

--- a/tests/Unit/ScraperTest.php
+++ b/tests/Unit/ScraperTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatPysScraper\Tests\Unit;
 
+use GuzzleHttp\Psr7\Response;
 use LogicException;
+use PhpCfdi\SatPysScraper\Exceptions\HttpException;
+use PhpCfdi\SatPysScraper\Exceptions\HttpServerException;
 
 final class ScraperTest extends TestCase
 {
@@ -27,5 +30,25 @@ final class ScraperTest extends TestCase
         $scraper = $this->createFakeScraper();
         $this->expectException(LogicException::class);
         $scraper->obtainClasses(2711, 27, 1);
+    }
+
+    public function testObtainTypesThrowsExceptionOnServerError(): void
+    {
+        $scraper = $this->createPreparedScraperQueue([
+            new Response(500, body: 'Internal server error'),
+        ]);
+
+        $this->expectException(HttpServerException::class);
+        $scraper->obtainTypes();
+    }
+
+    public function testObtainTypesThrowsExceptionOnRequestError(): void
+    {
+        $scraper = $this->createPreparedScraperQueue([
+            new Response(404, body: 'Not found'),
+        ]);
+
+        $this->expectException(HttpException::class);
+        $scraper->obtainTypes();
     }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\SatPysScraper\Tests\Unit;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use LogicException;
 use PhpCfdi\SatPysScraper\Scraper;
 use PhpCfdi\SatPysScraper\ScraperInterface;
@@ -66,6 +68,15 @@ abstract class TestCase extends \PhpCfdi\SatPysScraper\Tests\TestCase
             ]],
         ]);
         $client = new Client(['handler' => $handler]);
+        return new Scraper($client);
+    }
+
+    /** @param array<mixed> $queue */
+    public function createPreparedScraperQueue(array $queue): ScraperInterface
+    {
+        $mockHandler = new MockHandler($queue);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handlerStack]);
         return new Scraper($client);
     }
 


### PR DESCRIPTION
Se modifica el script de ejecución y la prueba funcional para poder reintentar en caso de que el 
servidor del SAT devuelva un estado HTTP 500. Esto sucede frecuentemente desde hace un par de meses.

Se cambia la construcción de imagen de docker, ahora depende de `php:8.3-cli-alpine`.

Se actualiza el archivo de licencia a 2024.

Se hacen otros cambios en el entorno de desarrollo:

- Se prueba el correcto orden para llamar a los métodos para obtener datos.
- Se utiliza la variable `php-version` en singular para las matrices de pruebas.
- Se actualizan las herramientas de desarrollo.