### PR TITLE
Mejorar `bin/sat-pys-scraper` con `MAX_TRIES`

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -44,3 +44,5 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist --no-dev
       - name: System test with PHP ${{ matrix.php-version }}
         run: php bin/sat-pys-scraper --json build/result.json --xml build/result.xml --sort key
+        env:
+          MAX_TRIES: 5

--- a/bin/sat-pys-scraper
+++ b/bin/sat-pys-scraper
@@ -7,4 +7,15 @@ use PhpCfdi\SatPysScraper\App\SatPysScraper;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-exit(SatPysScraper::run($argv));
+exit(call_user_func(function (string ...$argv): int {
+    $result = 1;
+    $maxTries = ($_SERVER['MAX_TRIES'] ?? null) ?? ($_ENV['MAX_TRIES'] ?? null);
+    $maxTries = is_numeric($maxTries) ? intval($maxTries) : 1;
+    for ($try = 0; $try < $maxTries; $try++) {
+        $result = SatPysScraper::run($argv);
+        if (0 === $result) {
+            break;
+        }
+    }
+    return $result;
+}, ...$argv));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,15 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 3.0.2 2024-10-17
+
+A la herramienta `bin/sat-pys-scraper` se le puede definir un número máximo de ejecuciones en la 
+variable de entorno `MAX_TRIES`, de forma predeterminada usa el valor `1`. 
+Con este cambio se intenta resolver el problema de error `500 Internal Server Error` de la 
+aplicación de Productos y Servicios del SAT.
+
+En el flujo de trabajo `system.yml` en el trabajo `system-tests` se configura `MAX_TRIES` a `5`.
+
 ### Versión 3.0.1 2024-10-15
 
 La aplicación del SAT devuelve un error 500 frecuentemente (1 de cada 3 veces) desde 2024-07-15.


### PR DESCRIPTION
A la herramienta `bin/sat-pys-scraper` se le puede definir un número máximo de ejecuciones en la 
variable de entorno `MAX_TRIES`, de forma predeterminada usa el valor `1`. 
Con este cambio se intenta resolver el problema de error `500 Internal Server Error` de la 
aplicación de Productos y Servicios del SAT.

En el flujo de trabajo `system.yml` en el trabajo `system-tests` se configura `MAX_TRIES` a `5`.
