### PR TITLE
Refactorizar reintentos y limpiar aplicación (versión 4)

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -43,6 +43,4 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist --no-dev
       - name: System test with PHP ${{ matrix.php-version }}
-        run: php bin/sat-pys-scraper --json build/result.json --xml build/result.xml --sort key
-        env:
-          MAX_TRIES: 5
+        run: php bin/sat-pys-scraper --tries 5 --json build/result.json --xml build/result.xml --sort key

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ sin temor a romper tu aplicación.
 |---------|----------|-----------------------------------|
 | 1.0.0   | 8.2, 8.3 | 2023-12-13 Fuera de mantenimiento |
 | 2.0.0   | 8.2, 8.3 | 2024-03-07 Fuera de mantenimiento |
-| 3.0.0   | 8.2, 8.3 | 2024-03-07                        |
+| 3.0.0   | 8.2, 8.3 | 2024-03-07 Fuera de mantenimiento |
+| 4.0.0   | 8.2, 8.3 | 2024-10-17                        |
 
 ## Contribuciones
 

--- a/bin/sat-pys-scraper
+++ b/bin/sat-pys-scraper
@@ -7,15 +7,4 @@ use PhpCfdi\SatPysScraper\App\SatPysScraper;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-exit(call_user_func(function (string ...$argv): int {
-    $result = 1;
-    $maxTries = ($_SERVER['MAX_TRIES'] ?? null) ?? ($_ENV['MAX_TRIES'] ?? null);
-    $maxTries = is_numeric($maxTries) ? intval($maxTries) : 1;
-    for ($try = 0; $try < $maxTries; $try++) {
-        $result = SatPysScraper::run($argv);
-        if (0 === $result) {
-            break;
-        }
-    }
-    return $result;
-}, ...$argv));
+exit((new SatPysScraper())->run($argv));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,21 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 4.0.0 2024-10-17
+
+Esta es una actualización de refactorización que obliga a crear una versión mayor.
+Si no utilizas entidades del espacio de nombres `PhpCfdi\SatPysScraper\App` entonces puedes hacer el cambio 
+de la versión `3.x` a la versión `4.x` sin conflictos. En caso contrario debes revisar tu implementación. 
+
+- Se agrega el parámetro `--debug` que, si existe, vuelca los datos del error de ejecución.
+- Se agrega el parámetro `--tries` que, si existe, reintenta la descarga de información hasta ese número de veces.
+- Se extrae el procesamiento de argumentos a su propia clase.
+- Se extrae el almacenamiento de argumentos a su propia clase en lugar de un arreglo.
+- Se reorganizan las pruebas de acuerdo a los cambios previos.
+- La ejecución del flujo de trabajo `system.yml` en el trabajo `system-tests` se configura con `--tries 5`.
+- Se vuelve a simplificar la herramienta `bin/sat-pys-scraper` para que toda su lógica esté probada.
+- Ya no se usa la variable de entorno `MAX_TRIES`.
+
 ### Versión 3.0.2 2024-10-17
 
 A la herramienta `bin/sat-pys-scraper` se le puede definir un número máximo de ejecuciones en la 

--- a/src/App/Arguments.php
+++ b/src/App/Arguments.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\App;
+
+final readonly class Arguments
+{
+    public function __construct(
+        public string $xml,
+        public string $json,
+        public string $sort,
+        public int $tries,
+        public bool $quiet,
+        public bool $debug,
+    ) {
+    }
+}

--- a/src/App/ArgumentsBuilder.php
+++ b/src/App/ArgumentsBuilder.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\App;
+
+final class ArgumentsBuilder
+{
+    private string $xml = '';
+
+    private string $json = '';
+
+    private string $sort = 'key';
+
+    private int $tries = 1;
+
+    private bool $quiet = false;
+
+    private bool $debug = false;
+
+    /** @throws ArgumentException */
+    public function build(string ...$arguments): Arguments
+    {
+        $arguments = array_values($arguments);
+        while ([] !== $arguments) {
+            $argument = (string) array_shift($arguments);
+            match (true) {
+                in_array($argument, ['--xml', '-x'], true) => $this->setXml((string) array_shift($arguments)),
+                in_array($argument, ['--json', '-j'], true) => $this->setJson((string) array_shift($arguments)),
+                in_array($argument, ['--sort', '-s'], true) => $this->setSort((string) array_shift($arguments)),
+                in_array($argument, ['--tries', '-t'], true) => $this->setTries((string) array_shift($arguments)),
+                in_array($argument, ['--quiet', '-q'], true) => $this->setQuiet(),
+                in_array($argument, ['--debug', '-d'], true) => $this->setDebug(),
+                default => throw new ArgumentException(sprintf('Invalid argument "%s"', $argument)),
+            };
+        }
+
+        if ('' === $this->xml && '' === $this->json) {
+            throw new ArgumentException('Did not specify --xml or --json arguments');
+        }
+        if ('-' === $this->xml && '-' === $this->json) {
+            throw new ArgumentException('Cannot send --xml and --json result to standard output at the same time');
+        }
+
+        return new Arguments(
+            xml: '-' === $this->xml ? 'php://stdout' : $this->xml,
+            json: '-' === $this->json ? 'php://stdout' : $this->json,
+            sort: $this->sort,
+            tries: $this->tries,
+            quiet: $this->quiet,
+            debug: $this->debug,
+        );
+    }
+
+    private function setXml(string $argument): void
+    {
+        $this->xml = $argument;
+        if ('-' === $argument) {
+            $this->quiet = true;
+        }
+    }
+
+    private function setJson(string $argument): void
+    {
+        $this->json = $argument;
+        if ('-' === $argument) {
+            $this->quiet = true;
+        }
+    }
+
+    /** @throws ArgumentException */
+    private function setSort(string $argument): void
+    {
+        if (! in_array($argument, ['key', 'name'], true)) {
+            throw new ArgumentException(sprintf('Invalid sort "%s"', $argument));
+        }
+        $this->sort = $argument;
+    }
+
+    /** @throws ArgumentException */
+    private function setTries(string $argument): void
+    {
+        $this->tries = (int) $argument;
+        if ((string) $this->tries !== $argument || $this->tries < 1) {
+            throw new ArgumentException(sprintf('Invalid tries "%s"', $argument));
+        }
+    }
+
+    private function setQuiet(): void
+    {
+        $this->quiet = true;
+    }
+
+    private function setDebug(): void
+    {
+        $this->debug = true;
+    }
+}

--- a/tests/Unit/App/ArgumentsBuilderTest.php
+++ b/tests/Unit/App/ArgumentsBuilderTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatPysScraper\Tests\Unit\App;
+
+use PhpCfdi\SatPysScraper\App\ArgumentException;
+use PhpCfdi\SatPysScraper\App\ArgumentsBuilder;
+use PhpCfdi\SatPysScraper\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
+
+final class ArgumentsBuilderTest extends TestCase
+{
+    public function testXmlOutputToStandard(): void
+    {
+        $arguments = ['--xml', '-'];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertSame('php://stdout', $result->xml);
+        $this->assertTrue($result->quiet);
+    }
+
+    public function testXmlOutputToFile(): void
+    {
+        $outputFile = '/tmp/result.xml';
+        $arguments = ['-x', $outputFile];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertSame($outputFile, $result->xml);
+        $this->assertFalse($result->quiet);
+    }
+
+    public function testJsonOutputToStandard(): void
+    {
+        $arguments = ['--json', '-'];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertSame('php://stdout', $result->json);
+        $this->assertTrue($result->quiet);
+    }
+
+    public function testJsonOutputToFile(): void
+    {
+        $outputFile = '/tmp/result.xml';
+        $arguments = ['-j', $outputFile];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertSame($outputFile, $result->json);
+        $this->assertFalse($result->quiet);
+    }
+
+    #[TestWith(['--quiet'])]
+    #[TestWith(['-q'])]
+    public function testQuiet(string $quiet): void
+    {
+        $arguments = ['-j', '/tmp/output', $quiet];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertTrue($result->quiet);
+    }
+
+    #[TestWith(['--debug'])]
+    #[TestWith(['-d'])]
+    public function testDebug(string $debug): void
+    {
+        $arguments = ['-j', '/tmp/output', $debug];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertTrue($result->debug);
+    }
+
+    public function testSetAll(): void
+    {
+        $arguments = [
+            '--xml', 'result.xml',
+            '--json', 'result.json',
+            '--sort', 'name',
+            '--tries', '5',
+            '--quiet',
+            '--debug',
+        ];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertSame('result.xml', $result->xml);
+        $this->assertSame('result.json', $result->json);
+        $this->assertSame('name', $result->sort);
+        $this->assertSame(5, $result->tries);
+        $this->assertTrue($result->quiet);
+        $this->assertTrue($result->debug);
+    }
+
+    public function testSetMinimal(): void
+    {
+        $arguments = ['--xml', 'output'];
+        $builder = new ArgumentsBuilder();
+
+        $result = $builder->build(...$arguments);
+
+        $this->assertSame('output', $result->xml);
+        $this->assertSame('', $result->json);
+        $this->assertSame('key', $result->sort);
+        $this->assertSame(1, $result->tries);
+        $this->assertFalse($result->quiet);
+        $this->assertFalse($result->debug);
+    }
+
+    public function testEmpty(): void
+    {
+        $arguments = [];
+        $builder = new ArgumentsBuilder();
+
+        $this->expectException(ArgumentException::class);
+        $this->expectExceptionMessage('Did not specify --xml or --json arguments');
+        $builder->build(...$arguments);
+    }
+
+    public function testWithXmlAndJsonOutputToStdout(): void
+    {
+        $arguments = ['-x', '-', '-j', '-'];
+        $builder = new ArgumentsBuilder();
+
+        $this->expectException(ArgumentException::class);
+        $this->expectExceptionMessage('Cannot send --xml and --json result to standard output at the same time');
+        $builder->build(...$arguments);
+    }
+
+    public function testWithExtra(): void
+    {
+        $arguments = ['extra-argument'];
+        $builder = new ArgumentsBuilder();
+
+        $this->expectException(ArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument "extra-argument"');
+        $builder->build(...$arguments);
+    }
+
+    public function testWithInvalidSort(): void
+    {
+        $arguments = ['--sort', 'foo'];
+        $builder = new ArgumentsBuilder();
+
+        $this->expectException(ArgumentException::class);
+        $this->expectExceptionMessage('Invalid sort "foo"');
+        $builder->build(...$arguments);
+    }
+
+    #[TestWith(['0'])]
+    #[TestWith(['-1'])]
+    #[TestWith(['not integer'])]
+    #[TestWith([''])]
+    public function testWithInvalidTries(string $tries): void
+    {
+        $arguments = ['--tries', $tries];
+        $builder = new ArgumentsBuilder();
+
+        $this->expectException(ArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Invalid tries "%s"', $tries));
+        $builder->build(...$arguments);
+    }
+
+    #[TestWith(['--xml'])]
+    #[TestWith(['--json'])]
+    public function testWithoutOutput(string $format): void
+    {
+        $arguments = [$format, ''];
+        $builder = new ArgumentsBuilder();
+
+        $this->expectException(ArgumentException::class);
+        $this->expectExceptionMessage('Did not specify --xml or --json arguments');
+        $builder->build(...$arguments);
+    }
+}


### PR DESCRIPTION
Esta es una actualización de refactorización que obliga a crear una versión mayor.
Si no utilizas entidades del espacio de nombres `PhpCfdi\SatPysScraper\App` entonces puedes hacer el cambio de la versión `3.x` a la versión `4.x` sin conflictos. En caso contrario debes revisar tu implementación. 

- Se agrega el parámetro `--debug` que, si existe, vuelca los datos del error de ejecución.
- Se agrega el parámetro `--tries` que, si existe, reintenta la descarga de información hasta ese número de veces.
- Se extrae el procesamiento de argumentos a su propia clase.
- Se extrae el almacenamiento de argumentos a su propia clase en lugar de un arreglo.
- Se reorganizan las pruebas de acuerdo a los cambios previos.
- La ejecución del flujo de trabajo `system.yml` en el trabajo `system-tests` se configura con `--tries 5`.
- Se vuelve a simplificar la herramienta `bin/sat-pys-scraper` para que toda su lógica esté probada.
- Ya no se usa la variable de entorno `MAX_TRIES`.
