### PR TITLE
PHP 8.3 (version 5.0.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ sin temor a romper tu aplicación.
 | 1.0.0   | 8.2, 8.3      | 2023-12-13 Fuera de mantenimiento |
 | 2.0.0   | 8.2, 8.3      | 2024-03-07 Fuera de mantenimiento |
 | 3.0.0   | 8.2, 8.3      | 2024-03-07 Fuera de mantenimiento |
-| 4.0.0   | 8.2, 8.3, 8.4 | 2024-10-17                        |
+| 4.0.0   | 8.2, 8.3, 8.4 | 2024-10-17 Fuera de mantenimiento |
+| 5.0.0   | 8.3, 8.4      | 2025-11-13                        |
 
 ## Contribuciones
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/dom-crawler": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^12.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/phpcfdi/sat-pys-scraper"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-dom": "*",
         "guzzlehttp/guzzle": "^7.8",
         "symfony/css-selector": "^7.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,11 +11,11 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
-### Versión 4.0.2 2024-11-13
+### Versión 4.0.2 2025-11-13
 
 Se corrige la imagen de Docker incluyendo la dependencia `libzip`.
 
-### Versión 4.0.1 2024-11-13
+### Versión 4.0.1 2025-11-13
 
 Esta actualización confirma la compatibilidad (que ya existía) con PHP 8.4.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,19 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 5.0.0 2025-11-13
+
+Se elimina la compatibilidad con PHP 8.2. Se mantiene PHP 8.3 y PHP 8.4.
+
+Si estás usando esta herramienta en una implementación de la librería, 
+esta versión no presenta cambios significativos a tu código.
+
+- Se establece el tipo `string` a la constante `Scraper::PYS_URL`.
+
+En el entorno de desarrollo:
+
+- Se actualiza PHPUnit a la versión 12.4.
+
 ### Versión 4.0.2 2025-11-13
 
 Se corrige la imagen de Docker incluyendo la dependencia `libzip`.

--- a/src/App/ArgumentsBuilder.php
+++ b/src/App/ArgumentsBuilder.php
@@ -23,7 +23,7 @@ final class ArgumentsBuilder
     {
         $arguments = array_values($arguments);
         while ([] !== $arguments) {
-            $argument = (string) array_shift($arguments);
+            $argument = array_shift($arguments);
             match (true) {
                 in_array($argument, ['--xml', '-x'], true) => $this->setXml((string) array_shift($arguments)),
                 in_array($argument, ['--json', '-j'], true) => $this->setJson((string) array_shift($arguments)),

--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -14,7 +14,7 @@ use Symfony\Component\DomCrawler\Crawler;
 final class Scraper implements ScraperInterface
 {
     /** @noinspection HttpUrlsUsage */
-    public const PYS_URL = 'http://pys.sat.gob.mx/PyS/catPyS.aspx';
+    public const string PYS_URL = 'http://pys.sat.gob.mx/PyS/catPyS.aspx';
 
     private Crawler|null $crawler = null;
 

--- a/tests/Fakes/PysSimulator.php
+++ b/tests/Fakes/PysSimulator.php
@@ -24,8 +24,7 @@ final readonly class PysSimulator
     {
     }
 
-    /** @param array<mixed> $options */
-    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    public function __invoke(RequestInterface $request): PromiseInterface
     {
         if ('GET' === $request->getMethod()) {
             return $this->promise($this->createTypes());

--- a/tests/Integration/ScraperTest.php
+++ b/tests/Integration/ScraperTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatPysScraper\Tests\TestCase;
 
 class ScraperTest extends TestCase
 {
-    private const MAX_RETRIES = 5;
+    private const int MAX_RETRIES = 5;
 
     public function testObtainSequence(): void
     {


### PR DESCRIPTION
Se elimina la compatibilidad con PHP 8.2. Se mantiene PHP 8.3 y PHP 8.4.

Si estás usando esta herramienta en una implementación de la librería, 
esta versión no presenta cambios significativos a tu código.

- Se establece el tipo `string` a la constante `Scraper::PYS_URL`.

En el entorno de desarrollo:

- Se actualiza PHPUnit a la versión 12.4.